### PR TITLE
Fix Shelters map bounds

### DIFF
--- a/src/containers/shelters/actions.js
+++ b/src/containers/shelters/actions.js
@@ -30,7 +30,7 @@ export const fetchSingleShelter = (id) => {
       type: FETCH_SINGLE_SHELTER,
     });
 
-    return fetchJson(`https://stageapi.hittaskyddsrum.se/api/v2/shelters/${id}`)
+    return fetchJson(`https://api.hittaskyddsrum.se/api/v2/shelters/${id}`)
       .then(shelter => dispatch({
         type: FETCH_SINGLE_SHELTER_SUCCESS,
         shelter,
@@ -48,7 +48,7 @@ export const fetchShelters = (lat, lon) => {
       type: FETCH_SHELTERS,
     });
 
-    return fetchJson(`https://stageapi.hittaskyddsrum.se/api/v2/shelters/?lat=${lat}&long=${lon}`)
+    return fetchJson(`https://api.hittaskyddsrum.se/api/v2/shelters/?lat=${lat}&long=${lon}`)
       .then(shelters => dispatch({
         type: FETCH_SHELTERS_SUCCESS,
         shelters,

--- a/src/containers/shelters/actions.js
+++ b/src/containers/shelters/actions.js
@@ -30,7 +30,7 @@ export const fetchSingleShelter = (id) => {
       type: FETCH_SINGLE_SHELTER,
     });
 
-    return fetchJson(`https://api.hittaskyddsrum.se/api/v2/shelters/${id}`)
+    return fetchJson(`https://stageapi.hittaskyddsrum.se/api/v2/shelters/${id}`)
       .then(shelter => dispatch({
         type: FETCH_SINGLE_SHELTER_SUCCESS,
         shelter,
@@ -48,7 +48,7 @@ export const fetchShelters = (lat, lon) => {
       type: FETCH_SHELTERS,
     });
 
-    return fetchJson(`https://api.hittaskyddsrum.se/api/v2/shelters/?lat=${lat}&long=${lon}`)
+    return fetchJson(`https://stageapi.hittaskyddsrum.se/api/v2/shelters/?lat=${lat}&long=${lon}`)
       .then(shelters => dispatch({
         type: FETCH_SHELTERS_SUCCESS,
         shelters,

--- a/src/containers/shelters/actions.js
+++ b/src/containers/shelters/actions.js
@@ -55,6 +55,7 @@ export const fetchShelters = (lat, lon) => {
       }))
       .then(({ shelters }) => dispatch(
         setBoundsForPositions(shelters
+          .slice(0, 10)
           .map(({ position: { lat: shelterLat, long: shelterLong } }) => [shelterLat, shelterLong])
           .concat([[lat, lon]])
         )


### PR DESCRIPTION
Ensure that the map bounds always is based on 10 closest shelters, no matter how many the API returns.